### PR TITLE
added reminder to create branch before editing in TLDR instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Our FCC forum post: (https://forum.freecodecamp.org/t/git-and-github-practice-fo
 
 2. Keep your fork synched! You need to create a git clone in your local storage, the step by step guide is available here https://help.github.com/articles/fork-a-repo/
 
-3. Now open the files in your own text editor of choice. You will find the files in "The Website" folder.
+3. Make a new branch (see instructions below) and then open the files in your own text editor of choice. You will find the files in "The Website" folder.
 
 4. Write your name anywhere in the file so it shows up in the webpage!
 


### PR DESCRIPTION
The TLDR instructions don't say to make a new branch before you start to edit.  Then you get to the instructions of actually making the PR and it says you needed to make a new branch first.  I had already committed and pushed to my fork by the time I saw that.  Maybe there's a way to fix that in git but as a git newbie I just ended up deleting my work and re-doing it.  So adding just these few words of text might keep someone else from having the same problem.  Thanks, and thanks for setting this up