### PR TITLE
Added links to Resources 

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,15 @@
             <li>
               <a href="https://help.github.com/articles/about-pull-requests/">Pull Requests</a>
             </li>
+            <li>
+              <a href="https://devdocs.io">DevDocs</a>
+            </li>
+            <li>
+              <a href="https://github.com/JABedford/Front-End-Bible">the Front End Bible</a>
+            </li>
+            <li>
+              <a href="https://guide.freecodecamp.org/">fCC Library</a>
+            </li>
           </ul>
         </section>
         <section id="contributors">


### PR DESCRIPTION
Three links relevant to DevDocs, the Front End Bible (sibling site), and the fCC library were added to the Resources section to help assist potential users with Git. Per #95 - these were the links @DarrenfJ requested to be added. Let me know if I can make any changes or assist any further.